### PR TITLE
Aggregate RSpec failures and allow multiple expectations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,9 @@ Metrics/BlockLength:
 
 Metrics/MethodLength:
   Max: 30
+
+RSpec/ExampleLength:
+  Max: 10
+
+RSpec/MultipleExpectations:
+  Max: 10

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,11 @@ RSpec.configure do |config|
   config.default_formatter = 'doc'
   config.profile_examples = 10
   config.order = :random
+
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true
+  end
+
   Kernel.srand config.seed
 
   config.include Rack::Test::Methods, type: :http


### PR DESCRIPTION
It is not informative and/or useful to only have one expectation per test case